### PR TITLE
Use vctrs rather than dplyr for dfr/dfc functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     lifecycle (>= 0.2.0),
     purrr (>= 0.3.0),
     rlang (>= 0.3.0),
-    vctrs
+    vctrs (>= 0.3.2)
 Suggests:
     covr,
     dplyr (>= 0.7.4),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # furrr 0.1.0.9002
 
+* `future_map_dfr()`, `future_map_dfc()`, and their variants now use vctrs
+  rather than dplyr to bind the results (#143).
+
 * `furrr_options()` now has a variety of new arguments for fine tuning furrr.
   These are based on advancements made in both future and future.apply. The
   most important is `chunk_size`, which can be used as an alternative

--- a/R/future-map.R
+++ b/R/future-map.R
@@ -183,12 +183,17 @@ future_map_dfr <- function(.x,
                            .progress = deprecated()) {
   maybe_warn_deprecated_progress(is_present(.progress), what = "future_map_dfr")
 
-  if (!rlang::is_installed("dplyr")) {
-    rlang::abort("`future_map_dfr()` requires dplyr")
-  }
+  names_to <- compat_id(.id)
 
-  res <- future_map(.x, .f, ..., .options = .options, .env_globals = .env_globals)
-  dplyr::bind_rows(res, .id = .id)
+  out <- future_map(
+    .x = .x,
+    .f = .f,
+    ...,
+    .options = .options,
+    .env_globals = .env_globals
+  )
+
+  vctrs::vec_rbind(!!!out, .names_to = names_to)
 }
 
 #' @rdname future_map
@@ -201,12 +206,15 @@ future_map_dfc <- function(.x,
                            .progress = deprecated()) {
   maybe_warn_deprecated_progress(is_present(.progress), what = "future_map_dfc")
 
-  if (!rlang::is_installed("dplyr")) {
-    rlang::abort("`future_map_dfc()` requires dplyr")
-  }
+  out <- future_map(
+    .x = .x,
+    .f = .f,
+    ...,
+    .options = .options,
+    .env_globals = .env_globals
+  )
 
-  res <- future_map(.x, .f, ..., .options = .options, .env_globals = .env_globals)
-  dplyr::bind_cols(res)
+  furrr_list_cbind(out)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/future-map2.R
+++ b/R/future-map2.R
@@ -180,12 +180,18 @@ future_map2_dfr <- function(.x,
                             .progress = deprecated()) {
   maybe_warn_deprecated_progress(is_present(.progress), what = "future_map2_dfr")
 
-  if (!rlang::is_installed("dplyr")) {
-    rlang::abort("`future_map2_dfr()` requires dplyr")
-  }
+  names_to <- compat_id(.id)
 
-  res <- future_map2(.x, .y, .f, ..., .options = .options, .env_globals = .env_globals)
-  dplyr::bind_rows(res, .id = .id)
+  out <- future_map2(
+    .x = .x,
+    .y = .y,
+    .f = .f,
+    ...,
+    .options = .options,
+    .env_globals = .env_globals
+  )
+
+  vctrs::vec_rbind(!!!out, .names_to = names_to)
 }
 
 #' @rdname future_map2
@@ -199,10 +205,14 @@ future_map2_dfc <- function(.x,
                             .progress = deprecated()) {
   maybe_warn_deprecated_progress(is_present(.progress), what = "future_map2_dfc")
 
-  if (!rlang::is_installed("dplyr")) {
-    rlang::abort("`future_map2_dfc()` requires dplyr")
-  }
+  out <- future_map2(
+    .x = .x,
+    .y = .y,
+    .f = .f,
+    ...,
+    .options = .options,
+    .env_globals = .env_globals
+  )
 
-  res <- future_map2(.x, .y, .f, ..., .options = .options, .env_globals = .env_globals)
-  dplyr::bind_cols(res)
+  furrr_list_cbind(out)
 }

--- a/R/future-pmap.R
+++ b/R/future-pmap.R
@@ -114,12 +114,17 @@ future_pmap_dfr <- function(.l,
                             .progress = deprecated()) {
   maybe_warn_deprecated_progress(is_present(.progress), what = "future_pmap_dfr")
 
-  if (!rlang::is_installed("dplyr")) {
-    rlang::abort("`future_map_dfr()` requires dplyr")
-  }
+  names_to <- compat_id(.id)
 
-  res <- future_pmap(.l, .f, ..., .options = .options, .env_globals = .env_globals)
-  dplyr::bind_rows(res, .id = .id)
+  out <- future_pmap(
+    .l = .l,
+    .f = .f,
+    ...,
+    .options = .options,
+    .env_globals = .env_globals
+  )
+
+  vctrs::vec_rbind(!!!out, .names_to = names_to)
 }
 
 #' @rdname future_map2
@@ -132,10 +137,13 @@ future_pmap_dfc <- function(.l,
                             .progress = deprecated()) {
   maybe_warn_deprecated_progress(is_present(.progress), what = "future_pmap_dfc")
 
-  if (!rlang::is_installed("dplyr")) {
-    rlang::abort("`future_map_dfc()` requires dplyr")
-  }
+  out <- future_pmap(
+    .l = .l,
+    .f = .f,
+    ...,
+    .options = .options,
+    .env_globals = .env_globals
+  )
 
-  res <- future_pmap(.l, .f, ..., .options = .options, .env_globals = .env_globals)
-  dplyr::bind_cols(res)
+  furrr_list_cbind(out)
 }

--- a/tests/testthat/test-future-map.R
+++ b/tests/testthat/test-future-map.R
@@ -120,12 +120,12 @@ furrr_test_that("named input won't create packed data frames in `future_map_dfc(
 
   expect_identical(
     future_map_dfc(x, make_df),
-    data.frame(...1 = "foo", b = 1, c = 1)
+    data.frame(...1 = "foo", b = 1, c = 1, stringsAsFactors = FALSE)
   )
 
   expect_identical(
     future_map_dfc(y, make_df),
-    data.frame(x = "foo", b = 1, c = 1)
+    data.frame(x = "foo", b = 1, c = 1, stringsAsFactors = FALSE)
   )
 })
 

--- a/tests/testthat/test-future-map.R
+++ b/tests/testthat/test-future-map.R
@@ -83,6 +83,52 @@ furrr_test_that("future_map_dfc() works", {
   )
 })
 
+furrr_test_that(".id works", {
+  x <- 1:3
+
+  out <- future_map_dfr(x, ~data.frame(x = .x), .id = "foo")
+  expect_identical(out$foo, 1:3)
+
+  x <- set_names(x, c("a", "b", "c"))
+
+  out <- future_map_dfr(x, ~data.frame(x = .x), .id = "foo")
+  expect_identical(out$foo, as.character(c("a", "b", "c")))
+})
+
+furrr_test_that("input names are used to name columns from vectors in `future_map_dfc()`", {
+  x <- 1:2
+  x <- rlang::set_names(x, c("x", "y"))
+
+  expect_identical(
+    future_map_dfc(x, ~.x),
+    data.frame(x = 1L, y = 2L)
+  )
+})
+
+furrr_test_that("named input won't create packed data frames in `future_map_dfc()`", {
+  x <- c("a", "b", "c")
+  y <- rlang::set_names(x, c("x", "y", "z"))
+
+  make_df <- function(x) {
+    if (x == "a") {
+      return("foo")
+    }
+
+    out <- rlang::set_names(list(1), x)
+    vctrs::new_data_frame(out)
+  }
+
+  expect_identical(
+    future_map_dfc(x, make_df),
+    data.frame(...1 = "foo", b = 1, c = 1)
+  )
+
+  expect_identical(
+    future_map_dfc(y, make_df),
+    data.frame(x = "foo", b = 1, c = 1)
+  )
+})
+
 # ------------------------------------------------------------------------------
 # size
 

--- a/tests/testthat/test-future-map2.R
+++ b/tests/testthat/test-future-map2.R
@@ -91,6 +91,18 @@ furrr_test_that("future_map2_dfc() works", {
   )
 })
 
+furrr_test_that(".id works", {
+  x <- 1:3
+
+  out <- future_map2_dfr(x, x, ~data.frame(x = .x), .id = "foo")
+  expect_identical(out$foo, 1:3)
+
+  x <- set_names(x, c("a", "b", "c"))
+
+  out <- future_map2_dfr(x, x, ~data.frame(x = .x), .id = "foo")
+  expect_identical(out$foo, as.character(c("a", "b", "c")))
+})
+
 # ------------------------------------------------------------------------------
 # size
 

--- a/tests/testthat/test-future-pmap.R
+++ b/tests/testthat/test-future-pmap.R
@@ -91,6 +91,18 @@ furrr_test_that("future_pmap_dfc() works", {
   )
 })
 
+furrr_test_that(".id works", {
+  x <- 1:3
+
+  out <- future_pmap_dfr(list(x, x), ~data.frame(x = .x), .id = "foo")
+  expect_identical(out$foo, 1:3)
+
+  x <- set_names(x, c("a", "b", "c"))
+
+  out <- future_pmap_dfr(list(x, x), ~data.frame(x = .x), .id = "foo")
+  expect_identical(out$foo, as.character(c("a", "b", "c")))
+})
+
 # ------------------------------------------------------------------------------
 # size
 


### PR DESCRIPTION
Closes #143 

For `vec_rbind()`, we need to map `.id` -> `.names_to`. I think that `.id = NULL` becomes `.names_to = zap()`. A character `.id` should pass through fine. I do not think it is possible to pass `.names_to = NULL` through to push the names onto the result as row names, but this is fine.

For `vec_cbind()`, it is a bit tricky to get this right because of the data frame packing behavior of `vec_cbind()`. We don't want this in `future_map_dfc()`, so we take special care to unname named elements that are data frames before calling `vec_cbind()`. We do want to keep the names on vector elements because that gets promoted to the corresponding column name.