### PR TITLE
Force `total_size` resolution

### DIFF
--- a/R/globals.R
+++ b/R/globals.R
@@ -7,19 +7,19 @@ get_globals_and_packages <- function(globals, packages, map_fn, fn, dots, env_gl
   globals_fn <- list(...furrr_fn = fn)
   globals_fn <- future::as.FutureGlobals(globals_fn)
   globals_fn <- future::resolve(globals_fn)
-  attr(globals_fn, "total_size") <- objectSize(globals_fn)
+  globals_fn <- set_total_size(globals_fn, objectSize(globals_fn))
 
   # Always get `...`.
   globals_dots <- list(...furrr_dots = dots)
   globals_dots <- future::as.FutureGlobals(globals_dots)
   globals_dots <- future::resolve(globals_dots)
-  attr(globals_dots, "total_size") <- objectSize(globals_dots)
+  globals_dots <- set_total_size(globals_dots, objectSize(globals_dots))
 
   # Always get `map_fn`
   globals_map_fn <- list(...furrr_map_fn = map_fn)
   globals_map_fn <- future::as.FutureGlobals(globals_map_fn)
   globals_map_fn <- future::resolve(globals_map_fn)
-  attr(globals_map_fn, "total_size") <- objectSize(globals_map_fn)
+  globals_map_fn <- set_total_size(globals_map_fn, objectSize(globals_map_fn))
 
   # Always get chunk specific placeholders
   globals_extra <- list(
@@ -29,7 +29,7 @@ get_globals_and_packages <- function(globals, packages, map_fn, fn, dots, env_gl
   )
   globals_extra <- future::as.FutureGlobals(globals_extra)
   globals_extra <- future::resolve(globals_extra)
-  attr(globals_extra, "total_size") <- objectSize(globals_extra)
+  globals_extra <- set_total_size(globals_extra, objectSize(globals_extra))
 
   globals_out <- c(
     globals_fn,
@@ -43,11 +43,14 @@ get_globals_and_packages <- function(globals, packages, map_fn, fn, dots, env_gl
   if (is_true(globals)) {
     # Lookup `.f` globals in the function env of `.f` (#153)
     env_fn <- fn_env(fn)
-    gp_fn <- future::getGlobalsAndPackages(fn, envir = env_fn, globals = TRUE)
 
+    gp_fn <- future::getGlobalsAndPackages(fn, envir = env_fn, globals = TRUE)
     gp_dots <- future::getGlobalsAndPackages(dots, envir = env_globals, globals = TRUE)
 
-    globals_out <- unique(c(globals_out, gp_fn$globals, gp_dots$globals))
+    globals_gp_fn <- enforce_future_globals(gp_fn$globals)
+    globals_gp_dots <- enforce_future_globals(gp_dots$globals)
+
+    globals_out <- unique(c(globals_out, globals_gp_fn, globals_gp_dots))
     packages_out <- unique(c(packages_out, gp_fn$packages, gp_dots$packages))
   }
 
@@ -55,15 +58,13 @@ get_globals_and_packages <- function(globals, packages, map_fn, fn, dots, env_gl
   # but be lax about it with `mustExist = FALSE`.
   if (is.character(globals)) {
     globals_chr <- globals::globalsByName(globals, envir = env_globals, mustExist = FALSE)
-    globals_chr <- future::as.FutureGlobals(globals_chr)
-
+    globals_chr <- enforce_future_globals(globals_chr)
     globals_out <- c(globals_out, globals_chr)
   }
 
   # Assume supplied named inputs are the globals.
   if (is.list(globals)) {
-    globals_lst <- future::as.FutureGlobals(globals)
-
+    globals_lst <- enforce_future_globals(globals)
     globals_out <- c(globals_out, globals_lst)
   }
 
@@ -75,4 +76,20 @@ get_globals_and_packages <- function(globals, packages, map_fn, fn, dots, env_gl
   out <- list(globals = globals_out, packages = packages_out)
 
   out
+}
+
+# ------------------------------------------------------------------------------
+
+# `getGlobalsAndPackages()` should always return a FutureGlobals object
+# with a non-NA `total_size`, but HenrikBengtsson/future#410 proves it
+# doesn't, so be careful and ensure correct behavior
+enforce_future_globals <- function(x) {
+  x <- future::as.FutureGlobals(x)
+
+  if (is.na(get_total_size(x))) {
+    objectSize <- import_future("objectSize")
+    x <- set_total_size(x, objectSize(x))
+  }
+
+  x
 }

--- a/R/template.R
+++ b/R/template.R
@@ -341,7 +341,10 @@ furrr_template <- function(args,
         globals = TRUE
       )
 
-      chunk_globals <- c(chunk_globals, chunk_args_gp$globals)
+      chunk_args_globals <- chunk_args_gp$globals
+      chunk_args_globals <- enforce_future_globals(chunk_args_globals)
+
+      chunk_globals <- c(chunk_globals, chunk_args_globals)
       chunk_globals <- unique(chunk_globals)
 
       chunk_packages <- c(chunk_packages, chunk_args_gp$packages)

--- a/R/template.R
+++ b/R/template.R
@@ -313,7 +313,7 @@ furrr_template <- function(args,
     globals_file <- list(...furrr_progress_file = file)
     globals_file <- future::as.FutureGlobals(globals_file)
     globals_file <- future::resolve(globals_file)
-    attr(globals_file, "total_size") <- objectSize(globals_file)
+    globals_file <- set_total_size(globals_file, objectSize(globals_file))
 
     globals <- c(globals, globals_file)
     # nocov end

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,3 +17,11 @@ import_from <- function(name, default = NULL, package) {
     stop(sprintf("No such '%s' function: %s()", package, name))
   }
 }
+
+get_total_size <- function(x) {
+  attr(x, "total_size", exact = TRUE)
+}
+set_total_size <- function(x, total_size) {
+  attr(x, "total_size") <- total_size
+  x
+}


### PR DESCRIPTION
It is possible for `getGlobalsAndPackages()` to return a `$globals` slot that isn't a FutureGlobals and doesn't have a resolved `total_size` attribute (https://github.com/HenrikBengtsson/future/issues/410). Here we try and resolve those edge cases manually to avoid double calls to `objectSize()`