### PR TITLE
Use `future::supportsMulticore()` directly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # furrr (development version)
 
+* Removed an internal call to `future:::supportsMulticore()` since it is no
+  longer internal (#174).
+
 # furrr 0.2.0
 
 ## Breaking changes:

--- a/tests/testthat/helper-furrr-test-that.R
+++ b/tests/testthat/helper-furrr-test-that.R
@@ -24,9 +24,7 @@ furrr_test_that <- function(desc, code) {
 supported_strategies <- function() {
   strategies <- c("sequential", "multisession", "multicore")
 
-  supportsMulticore <- import_future("supportsMulticore")
-
-  if (!supportsMulticore()) {
+  if (!future::supportsMulticore()) {
     strategies <- setdiff(strategies, "multicore")
   }
 


### PR DESCRIPTION
Closes #173 

I was going to remove `import_future()` altogether, but `import_future("objectSize")` is still pretty useful.