### PR TITLE
Fix condition expectations in prevision of testthat breaking change

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # furrr (development version)
 
+* Preemptively updated tests related to upcoming changes in testthat (#196).
+
 * Updated snapshot tests failing on CI related to changes in lifecycle 1.0.0
   (#193).
 

--- a/tests/testthat/test-deprecation.R
+++ b/tests/testthat/test-deprecation.R
@@ -1,15 +1,17 @@
 test_that("can use deprecated `future_options()`", {
   local_options(lifecycle_verbosity = "warning")
 
-  expect_identical(
-    expect_warning(future_options()),
-    furrr_options()
+  expect_warning(
+    expect_identical(
+      future_options(),
+      furrr_options()
+    )
   )
-  expect_identical(
-    expect_warning(
-      future_options(globals = "x", packages = "dplyr", seed = 1, lazy = TRUE, scheduling = 2)
-    ),
-    furrr_options(globals = "x", packages = "dplyr", seed = 1, lazy = TRUE, scheduling = 2)
+  expect_warning(
+    expect_identical(
+      future_options(globals = "x", packages = "dplyr", seed = 1, lazy = TRUE, scheduling = 2),
+      furrr_options(globals = "x", packages = "dplyr", seed = 1, lazy = TRUE, scheduling = 2)
+    )
   )
 })
 


### PR DESCRIPTION
We are planning a breaking change to the condition expectations in testthat release (see NEWS item in https://github.com/r-lib/testthat/pull/1401). This PR implements a preventive fix that works with and without the breaking change.

There is no hurry to get this fix on CRAN since we are skipping one released version of testthat before going through with the change.
