### PR TITLE
Update snapshot tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,5 +44,5 @@ Config/Needs/website:
     progressr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,10 +25,10 @@ Depends:
 Imports:
     ellipsis,
     globals (>= 0.13.1),
-    lifecycle (>= 1.0.0),
+    lifecycle (>= 1.0.1),
     purrr (>= 0.3.0),
-    rlang (>= 0.3.0),
-    vctrs (>= 0.3.2)
+    rlang (>= 1.0.2),
+    vctrs (>= 0.4.1)
 Suggests:
     carrier,
     covr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # furrr (development version)
 
+* lifecycle >=1.0.1, rlang >=1.0.2, and vctrs >=0.4.1 are now required (#214).
+
+* Updated snapshot tests related to how testthat prints condition details
+  (#213).
+
 # furrr 0.2.3
 
 * Preemptively updated tests related to upcoming changes in testthat (#196).

--- a/man/furrr-package.Rd
+++ b/man/furrr-package.Rd
@@ -8,10 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
 
-Implementations of the family of map() functions
-    from 'purrr' that can be resolved using any 'future'-supported
-    backend, e.g. parallel on the local machine or distributed on a
-    compute cluster.
+Implementations of the family of map() functions from 'purrr' that can be resolved using any 'future'-supported backend, e.g. parallel on the local machine or distributed on a compute cluster.
 }
 \seealso{
 Useful links:

--- a/tests/testthat/_snaps/deprecation.md
+++ b/tests/testthat/_snaps/deprecation.md
@@ -2,7 +2,8 @@
 
     Code
       future_options()
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       `future_options()` was deprecated in furrr 0.2.0.
       Please use `furrr_options()` instead.
     Output


### PR DESCRIPTION
Closes #213 

Also bumps required rlang, vctrs, and lifecycle dependencies to ensure that snapshots are all up to date.