### PR TITLE
Remove test about not loading furrr on the multisession workers

### DIFF
--- a/tests/testthat/test-future-map.R
+++ b/tests/testthat/test-future-map.R
@@ -218,28 +218,6 @@ test_that("globals in `.x` are only exported to workers that use them", {
   )
 })
 
-test_that("furrr is not loaded on the workers", {
-  # future has some workarounds when running covr to ensure
-  # that the libpath that covr uses is on the workers. I think
-  # that somehow this loads furrr, so we just avoid this test when doing covr.
-  # https://github.com/HenrikBengtsson/future/blob/d3a3e55cfdfd1bc4c47df3790923ad15c8c0bed1/R/ClusterFuture-class.R#L138
-  skip_if("covr" %in% loadedNamespaces())
-
-  plan(multisession, workers = 2)
-  on.exit(plan(sequential), add = TRUE)
-
-  # Evaluate in the global env to avoid furrr being
-  # in the parent envs of this fn
-  fn <- globally(function(x) {
-    isNamespaceLoaded("furrr")
-  })
-
-  expect_identical(
-    future_map_lgl(1:2, fn),
-    c(FALSE, FALSE)
-  )
-})
-
 furrr_test_that("base package functions can be exported to workers (HenrikBengtsson/future#401)", {
   expect_identical(future_map(1:2, identity), list(1L, 2L))
 })


### PR DESCRIPTION
Closes #215 

This has sucked up a whole bunch of time but has proven very difficult to completely nail down.

This one test is failing on CI on all versions of R except R < 3.6.3 (i.e. the 3.5.3 build seemed to work).

After much trial and error, I have tracked this down to the fact that the expressions that we generate in the package and send to the worker (like the linked one below) _sometimes_ contain srcref information, and when those expressions are unserialized on the worker it will load the furrr namespace based on information in the srcref, even if the expression itself doesn't require furrr.
https://github.com/DavisVaughan/furrr/blob/bfb1ce3a251d3ecdc7068a41daa7cb29ee2024d8/R/template.R#L23

There are various ways to make R retain the srcref information, all basically do the same thing eventually:
- Set `R_KEEP_PKG_SOURCE`, which is what CI does https://github.com/r-lib/actions/blob/4449c5d58a27381b9f03ffc16fee48b9e0fe591a/.github/workflows/check-full.yaml#L41
- Set `--with-keep.source` at R CMD INSTALL time directly, like with `devtools::install_github("DavisVaughan/furrr", INSTALL_opts = "--with-keep.source")`
- Set `keep_source = TRUE` in `devtools::install()`

The easiest way to reproduce the issue locally is with the last option. Open furrr in RStudio and run:

``` r
# devtools::install(keep_source = TRUE)

library(furrr)
#> Loading required package: future

fn <- function(x) {
  isNamespaceLoaded("furrr")
}

plan(multisession, workers = 2)

# bad! we dont want furrr on the worker
future_map(1:2, fn)
#> [[1]]
#> [1] TRUE
#> 
#> [[2]]
#> [1] TRUE
```

When we get packages from CRAN and when we do `load_all()`, we don't get the srcref info, so this is why it was hard to reproduce this problem.

To be clear, there is nothing in the globals or the packages that reference furrr in any way. It is the `expr` that eventually is passed to `future::future()` that has srcref information attached, and that srcref information is what loads furrr when the expression is unserialized on the worker side.

It seemed like zapping the srcref information was going to be enough to solve the problem, so I tried that in this commit https://github.com/DavisVaughan/furrr/pull/215/commits/3336a0c7fc1558f1216635021d6c1eb153acbb93. It worked on all platforms except for R-devel.

After more exploration, I discovered that the reason that this didn't work on R-devel is that often packages are installed from source on R-devel CI, including future, and because `R_KEEP_PKG_SOURCE` is set in the worker it installs with srcrefs. Somehow this causes furrr to be loaded on the worker even after we have removed the srcrefs from `expr` before we pass it on to `future::future()`. My best guess is that inside of `future()` the `expr` is modified again, and that somehow adds srcref info back on, and somehow that is enough to load furrr.

At any rate, I have decided that this isn't worth pursuing further. The main reason for this is that even though it _tries_ to load furrr while unserializing on the worker, if the furrr package isn't installed then it won't fail, and really everything will work fine.


---

@HenrikBengtsson you can reproduce this with future.apply too if you'd like to look into it further:

``` r
# remotes::install_github(
#   "HenrikBengtsson/future.apply@develop",
#   INSTALL_opts = "--with-keep.source",
#   force = TRUE
# )

library(future.apply)
#> Loading required package: future

fn <- function(x) {
  isNamespaceLoaded("future.apply")
}

plan(multisession, workers = 2)

future_lapply(1:2, fn)
#> [[1]]
#> [1] TRUE
#> 
#> [[2]]
#> [1] TRUE
```
