### PR TITLE
Support selectively ignoring conditions in `conditions`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # furrr (development version)
 
+* Condition objects are now dropped from future results before they are returned
+  to the main process (#216).
+
+* The `conditions` argument of `furrr_options()` now supports selectively
+  ignoring conditions through an `exclude` attribute. See `?furrr_options` for
+  more information (#181).
+
 * Unskipped a test now that the upstream bug in future is fixed
   (#218, HenrikBengtsson/future.apply#10).
 

--- a/R/template.R
+++ b/R/template.R
@@ -233,10 +233,6 @@ furrr_template <- function(args,
                            extract) {
   fn <- purrr::as_mapper(fn)
 
-  if (is.null(options$conditions)) {
-    options$conditions <- eval(formals(future::Future)[["conditions"]])
-  }
-
   if (is.null(options$seed) || is_false(options$seed)) {
     seeds <- NULL
   } else {

--- a/man/furrr_options.Rd
+++ b/man/furrr_options.Rd
@@ -7,7 +7,7 @@
 furrr_options(
   ...,
   stdout = TRUE,
-  conditions = NULL,
+  conditions = "condition",
   globals = TRUE,
   packages = NULL,
   lazy = FALSE,
@@ -29,10 +29,11 @@ relayed as soon as possible.
 \item If \code{NA}, output is not intercepted. This is not recommended.
 }}
 
-\item{conditions}{A character string of conditions classes to be captured
-and relayed. The default is the same as the condition argument of
-\code{\link[future:Future-class]{future::Future()}}. To not intercept conditions, use
-\code{conditions = character(0L)}. Errors are always relayed.}
+\item{conditions}{A character string of conditions classes to be relayed.
+The default is to relay all conditions, including messages and warnings.
+Errors are always relayed. To not relay any conditions (besides errors),
+use \code{conditions = character()}. To selectively ignore specific classes,
+use \code{conditions = structure("condition", exclude = "message")}.}
 
 \item{globals}{A logical, a character vector, a named list, or \code{NULL} for
 controlling how globals are handled. For details, see the

--- a/tests/testthat/_snaps/furrr-options.md
+++ b/tests/testthat/_snaps/furrr-options.md
@@ -1,0 +1,62 @@
+# can avoid handling conditions altogether
+
+    Code
+      future_map(1:5, fn, .options = opts)
+    Condition
+      Warning in `...furrr_fn()`:
+      hello
+      Warning in `...furrr_fn()`:
+      hello
+      Warning in `...furrr_fn()`:
+      hello
+      Warning in `...furrr_fn()`:
+      hello
+      Warning in `...furrr_fn()`:
+      hello
+    Output
+      [[1]]
+      [1] 1
+      
+      [[2]]
+      [1] 2
+      
+      [[3]]
+      [1] 3
+      
+      [[4]]
+      [1] 4
+      
+      [[5]]
+      [1] 5
+      
+
+---
+
+    Code
+      future_map(1:5, fn, .options = opts)
+    Output
+      [[1]]
+      [1] 1
+      
+      [[2]]
+      [1] 2
+      
+      [[3]]
+      [1] 3
+      
+      [[4]]
+      [1] 4
+      
+      [[5]]
+      [1] 5
+      
+
+# validates `conditions`
+
+    Code
+      (expect_error(furrr_options(conditions = 1)))
+    Output
+      <error/rlang_error>
+      Error in `validate_conditions()`:
+      ! `conditions` must be a character vector.
+


### PR DESCRIPTION
Also technically supports `NULL`, but this isn't encouraged

Closes #181 
Part of #216 