### PR TITLE
Avoid returning `.f` results back to the main process in `future_walk()` and friends

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # furrr (development version)
 
+* `future_walk()` and the other walk functions now avoid sending the results
+  of calling `.f` back to the main process (#205).
+
 * `future_options()` is now defunct and will be removed in the next minor
   release of furrr. Please use `furrr_options()` instead (#137).
 

--- a/R/future-walk.R
+++ b/R/future-walk.R
@@ -6,13 +6,15 @@ future_walk <- function(.x,
                         .options = furrr_options(),
                         .env_globals = parent.frame(),
                         .progress = FALSE) {
-  future_map(
-    .x = .x,
-    .f = .f,
-    ...,
-    .options = .options,
-    .env_globals = .env_globals,
-    .progress = .progress
+  furrr_map_template(
+    x = .x,
+    fn = .f,
+    dots = list(...),
+    options = .options,
+    progress = .progress,
+    type = "list",
+    map_fn = purrr::walk,
+    env_globals = .env_globals
   )
 
   invisible(.x)
@@ -27,14 +29,16 @@ future_walk2 <- function(.x,
                          .options = furrr_options(),
                          .env_globals = parent.frame(),
                          .progress = FALSE) {
-  future_map2(
-    .x = .x,
-    .y = .y,
-    .f = .f,
-    ...,
-    .options = .options,
-    .env_globals = .env_globals,
-    .progress = .progress
+  furrr_map2_template(
+    x = .x,
+    y = .y,
+    fn = .f,
+    dots = list(...),
+    options = .options,
+    progress = .progress,
+    type = "list",
+    map_fn = purrr::walk2,
+    env_globals = .env_globals
   )
 
   invisible(.x)
@@ -48,13 +52,15 @@ future_pwalk <- function(.l,
                          .options = furrr_options(),
                          .env_globals = parent.frame(),
                          .progress = FALSE) {
-  future_pmap(
-    .l = .l,
-    .f = .f,
-    ...,
-    .options = .options,
-    .env_globals = .env_globals,
-    .progress = .progress
+  furrr_pmap_template(
+    l = .l,
+    fn = .f,
+    dots = list(...),
+    options = .options,
+    progress = .progress,
+    type = "list",
+    map_fn = purrr::pwalk,
+    env_globals = .env_globals
   )
 
   invisible(.l)

--- a/tests/testthat/test-future-walk.R
+++ b/tests/testthat/test-future-walk.R
@@ -14,3 +14,114 @@ furrr_test_that("walk functions work", {
   out <- future_iwalk(x, ~"hello")
   expect_identical(out, x)
 })
+
+furrr_test_that("`future_walk()` - template returns `NULL`s (#205)", {
+  .x <- 1:2
+  .f <- identity
+  .options <- furrr_options()
+  .progress <- FALSE
+  .env_globals <- environment()
+
+  # `map()` template returns `.f` output
+  map_fn <- purrr::map
+  out <- furrr_map_template(
+    x = .x,
+    fn = .f,
+    dots = list(),
+    options = .options,
+    progress = .progress,
+    type = "list",
+    map_fn = map_fn,
+    env_globals = .env_globals
+  )
+  expect_identical(out, list(1L, 2L))
+
+  # `walk()` template returns `NULL`s
+  map_fn <- purrr::walk
+  out <- furrr_map_template(
+    x = .x,
+    fn = .f,
+    dots = list(),
+    options = .options,
+    progress = .progress,
+    type = "list",
+    map_fn = map_fn,
+    env_globals = .env_globals
+  )
+  expect_identical(out, list(NULL, NULL))
+})
+
+furrr_test_that("`future_walk2()` - template returns `NULL`s (#205)", {
+  .x <- 1:2
+  .y <- 3:4
+  .f <- function(x, y) c(x, y)
+  .options <- furrr_options()
+  .progress <- FALSE
+  .env_globals <- environment()
+
+  # `map2()` template returns `.f` output
+  map_fn <- purrr::map2
+  out <- furrr_map2_template(
+    x = .x,
+    y = .y,
+    fn = .f,
+    dots = list(),
+    options = .options,
+    progress = .progress,
+    type = "list",
+    map_fn = map_fn,
+    env_globals = .env_globals
+  )
+  expect_identical(out, list(c(1L, 3L), c(2L, 4L)))
+
+  # `walk2()` template returns `NULL`s
+  map_fn <- purrr::walk2
+  out <- furrr_map2_template(
+    x = .x,
+    y = .y,
+    fn = .f,
+    dots = list(),
+    options = .options,
+    progress = .progress,
+    type = "list",
+    map_fn = map_fn,
+    env_globals = .env_globals
+  )
+  expect_identical(out, list(NULL, NULL))
+})
+
+furrr_test_that("`future_pwalk()` - template returns `NULL`s (#205)", {
+  .l <- list(1:2, 3:4, 5:6)
+  .f <- function(x, y, z) c(x, y, z)
+  .options <- furrr_options()
+  .progress <- FALSE
+  .env_globals <- environment()
+
+  # `pmap()` template returns `.f` output
+  map_fn <- purrr::pmap
+  out <- furrr_pmap_template(
+    l = .l,
+    fn = .f,
+    dots = list(),
+    options = .options,
+    progress = .progress,
+    type = "list",
+    map_fn = map_fn,
+    env_globals = .env_globals
+  )
+  expect_identical(out, list(c(1L, 3L, 5L), c(2L, 4L, 6L)))
+
+  # `pwalk()` template returns `NULL`s
+  map_fn <- purrr::pwalk
+  out <- furrr_pmap_template(
+    l = .l,
+    fn = .f,
+    dots = list(),
+    options = .options,
+    progress = .progress,
+    type = "list",
+    map_fn = map_fn,
+    env_globals = .env_globals
+  )
+  expect_identical(out, list(NULL, NULL))
+})


### PR DESCRIPTION
Closes #205 