### PR TITLE
Vignette: Increment progressor after iteration

### DIFF
--- a/vignettes/articles/progress.Rmd
+++ b/vignettes/articles/progress.Rmd
@@ -50,9 +50,10 @@ my_pkg_fn <- function(x) {
   p <- progressor(steps = length(x))
   
   future_map(x, ~{
-    p()
     Sys.sleep(.2)
-    sum(.x)
+    out <- sum(.x)
+    p()
+    out
   })
 }
 ```
@@ -94,9 +95,10 @@ with_progress({
   p <- progressor(steps = length(x))
   
   result <- future_map(x, ~{
-    p()
     Sys.sleep(.2)
-    sum(.x)
+    out <- sum(.x)
+    p()
+    out
   })
 })
 #> |=====================                                               |  20%
@@ -110,9 +112,10 @@ Rather than writing an anonymous function, you might want to wrap the logic of `
 plan(multisession, workers = 2)
 
 fn <- function(x, p) {
-  p()
   Sys.sleep(.2)
-  sum(x)
+  out <- sum(x)
+  p()
+  out
 }
 
 with_progress({


### PR DESCRIPTION
I believe  the progress bar should start at 0% and reach 100% when all iterations are done. Therefore the progressor should advance when the task has finished, not when the task starts.

Otherwise the progress bar starts and immediately increases, and it stalls at 100% until the last iterations finish.

This pull request moves the `p()` to the end of the iteration to reach the described effect.

Thanks for your package and your time.

Feel free to close this if you disagree.